### PR TITLE
User creation response includes aliases

### DIFF
--- a/src/users/CreatesUsers.js
+++ b/src/users/CreatesUsers.js
@@ -23,9 +23,13 @@ class CreatesUsers {
     ];
 
     new ActionsExecutor(steps).run((err) => {
-      return err
-        ? callback(err)
-        : callback(null, {id: userId});
+      if (err)
+        return callback(err);
+
+      callback(null, {
+        id: userId,
+        aliases: aliases.reduce((ref, {type, value}) => (ref[type] = value, ref), {})
+      });
     });
   }
 }

--- a/tests/users/CreatesUsers.test.js
+++ b/tests/users/CreatesUsers.test.js
@@ -27,7 +27,13 @@ describe('CreatesUsers', () => {
 
     new CreatesUsers().create(userId, password, aliases, (err, response) => {
       expect(err).to.be.null;
-      expect(response).to.eql({id: 'jdoe'});
+      expect(response).to.eql({
+        id: 'jdoe',
+        aliases: {
+          email: 'jdoe@example.com',
+          name: 'jdoe'
+        }
+      });
       done();
     });
   });


### PR DESCRIPTION
Looks like events emitted from users always include full user profile. But calls to directory endpoints (creating or editing user) don't reply with full profile. So we'll need to fetch profiles every time.

I was thinking we add that to some endpoints. Creation seems easy, but I guess we'll have to query profile anyways, to keep things consistend (i.e. it does not make much sense to include that in login request).

What do you think?